### PR TITLE
Add vehicle management and editable info

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
       <label for="model" class="form-label">Araç Modeli</label>
       <select id="model" class="form-select"></select>
     </div>
+    <div class="input-group mb-3">
+      <input type="text" id="newModel" class="form-control" placeholder="Marka Model">
+      <button id="addVehicle" class="btn btn-outline-primary">Araç Ekle</button>
+    </div>
     <div class="mb-3">
       <label for="tuketim" class="form-label">100 km'de tüketim (L)</label>
       <input type="number" inputmode="decimal" step="0.1" id="tuketim" class="form-control" placeholder="Örn: 6.5">
@@ -69,6 +73,7 @@
 
   <div class="container my-3">
     <h2 class="text-center mb-3">Araç Bilgileri</h2>
+    <div id="aracForm">
     <div class="mb-3">
       <label for="lastikTarihi" class="form-label">Lastik Değişim Tarihi</label>
       <input type="date" id="lastikTarihi" class="form-control">
@@ -82,6 +87,7 @@
       <input type="date" id="bakimTarihi" class="form-control">
     </div>
     <button id="saveVehicle" class="btn btn-primary w-100">Kaydet</button>
+    </div>
     <div id="aracBilgiSonuc" class="mt-3 p-3 border rounded">Bilgiler burada görünecek</div>
   </div>
 
@@ -194,7 +200,10 @@
       sonucEl.innerHTML=`🔹 Tüketim: <strong>${toplamLitre.toFixed(2)} L</strong><br>🔸 Maliyet: <strong>${toplamTutar.toFixed(2)} TL</strong><br>👥 Kişi Başı: <strong>${kisiBasi.toFixed(2)} TL</strong><br>🌍 ≈ ${co2.toFixed(1)} kg CO₂`;
       setTimeout(()=>{sonucEl.style.opacity=1},10);
 
-      saveHistory({tuketim, fiyat, mesafe, yolcu, toplamTutar, tarih:new Date().toISOString()});
+      const idx=document.getElementById('model').value;
+      const vehicles=JSON.parse(localStorage.getItem(vehicleKey)||'[]');
+      const model=vehicles[idx]?vehicles[idx].model:'';
+      saveHistory({model, tuketim, fiyat, mesafe, yolcu, toplamTutar, tarih:new Date().toISOString()});
       renderChart();
       saveFormData();
     }
@@ -208,8 +217,8 @@
     function downloadCSV(){
       const arr=JSON.parse(localStorage.getItem(historyKey)||'[]');
       if(!arr.length) return;
-      const headers=['tuketim','fiyat','mesafe','yolcu','toplamTutar','tarih'];
-      const rows=[headers.join(',')].concat(arr.map(o=>headers.map(h=>o[h]).join(',')));
+      const headers=['model','tuketim','fiyat','mesafe','yolcu','toplamTutar','tarih'];
+      const rows=[headers.join(',')].concat(arr.map(o=>headers.map(h=>o[h]||'').join(',')));
       const blob=new Blob([rows.join('\n')],{type:'text/csv'});
       const url=URL.createObjectURL(blob);
       const a=document.createElement('a');
@@ -234,45 +243,72 @@
     }
 
     function kaydetAracBilgileri(){
-      const info={
+      const idx=document.getElementById('model').value;
+      if(idx==='') return;
+      const vehicles=JSON.parse(localStorage.getItem(vehicleKey)||'[]');
+      vehicles[idx].info={
         lastikTarihi:lastikTarihi.value,
         lastikKm:lastikKm.value,
         bakimTarihi:bakimTarihi.value
       };
-      localStorage.setItem('aracBilgileri',JSON.stringify(info));
+      localStorage.setItem(vehicleKey,JSON.stringify(vehicles));
       gosterAracBilgileri();
     }
 
     function gosterAracBilgileri(){
+      const idx=document.getElementById('model').value;
       const container=document.getElementById('aracBilgiSonuc');
-      const data=localStorage.getItem('aracBilgileri');
-      if(data){
-        const info=JSON.parse(data);
-        container.innerHTML=`🔧 Lastik Tarihi: <strong>${info.lastikTarihi||'-'}</strong><br>🏁 Lastik KM: <strong>${info.lastikKm||'-'}</strong><br>🔨 Bakım Tarihi: <strong>${info.bakimTarihi||'-'}</strong>`;
-      }else{
+      const form=document.getElementById('aracForm');
+      const vehicles=JSON.parse(localStorage.getItem(vehicleKey)||'[]');
+      if(idx===''||!vehicles[idx]||!vehicles[idx].info){
+        form.style.display='block';
         container.textContent='Henüz kayıt yok.';
+        return;
       }
+      const info=vehicles[idx].info;
+      form.style.display='none';
+      container.innerHTML=`🔧 Lastik Tarihi: <strong>${info.lastikTarihi||'-'}</strong><br>🏁 Lastik KM: <strong>${info.lastikKm||'-'}</strong><br>🔨 Bakım Tarihi: <strong>${info.bakimTarihi||'-'}</strong><br><button id="editInfo" class="btn btn-secondary mt-2">Güncelle</button>`;
+      document.getElementById('editInfo').addEventListener('click',()=>{
+        form.style.display='block';
+        lastikTarihi.value=info.lastikTarihi||'';
+        lastikKm.value=info.lastikKm||'';
+        bakimTarihi.value=info.bakimTarihi||'';
+        container.textContent='';
+      });
     }
 
     function loadVehicles(){
       const select=document.getElementById('model');
       const stored=JSON.parse(localStorage.getItem(vehicleKey)||'[]');
       select.innerHTML='<option value="">Seçiniz</option>';
-      stored.forEach(v=>{
+      stored.forEach((v,i)=>{
         const opt=document.createElement('option');
-        opt.value=v.avg;
+        opt.value=i;
         opt.textContent=v.model;
         select.appendChild(opt);
       });
-      select.addEventListener('change',()=>{
-        if(select.value) document.getElementById('tuketim').value=select.value;
-      });
+      select.addEventListener('change',gosterAracBilgileri);
+    }
+
+    function addVehicle(){
+      const input=document.getElementById('newModel');
+      const model=input.value.trim();
+      if(!model) return;
+      const vehicles=JSON.parse(localStorage.getItem(vehicleKey)||'[]');
+      vehicles.push({model});
+      localStorage.setItem(vehicleKey,JSON.stringify(vehicles));
+      input.value='';
+      loadVehicles();
+      const select=document.getElementById('model');
+      select.value=vehicles.length-1;
+      gosterAracBilgileri();
     }
 
     document.getElementById('themeBtn').addEventListener('click',toggleTheme);
     document.getElementById('langBtn').addEventListener('click',toggleLang);
     document.getElementById('calcBtn').addEventListener('click',hesapla);
     document.getElementById('saveVehicle').addEventListener('click',kaydetAracBilgileri);
+    document.getElementById('addVehicle').addEventListener('click',addVehicle);
     document.getElementById('downloadBtn').addEventListener('click',downloadCSV);
     window.addEventListener('DOMContentLoaded',init);
 


### PR DESCRIPTION
## Summary
- allow entering vehicle model manually and storing it
- persist maintenance info per vehicle
- display saved maintenance data with an update button
- save chosen vehicle with every calculation and export vehicle column in CSV

## Testing
- `tidy -eq index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714e025e80832ab91157bf86175529